### PR TITLE
Firmware: add CC_GET_STATE command with per slot pattern hashes

### DIFF
--- a/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_ble.cpp
+++ b/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_ble.cpp
@@ -73,7 +73,24 @@ enum CommCode {
   CC_SET_SPEED_OPTION,            // 18
   CC_SET_SPEED_OPTIONS,           // 19
   CC_SET_PATTERN_SHUFFLE_DURATION,// 20
+  CC_GET_STATE,                   // 21
 };
+
+// Get State response payload (all multi byte values big endian):
+//   displayState           1 byte  (0 = pattern, 1 = shuffle bank, 2 = shuffle all banks)
+//   patternBank            1 byte
+//   patternSlot            1 byte
+//   ledBrightness          1 byte
+//   animationSpeed         2 bytes
+//   patternShuffleDuration 1 byte  (seconds)
+//   sequencerStepCount     1 byte  (0 = no sequence loaded)
+//   sequencerStep          2 bytes (signed; -1 = about to start, stepCount = stopped)
+//   bankCount              1 byte
+//   bankSize               1 byte
+//   patternHashes          bankCount * bankSize * 4 bytes, ordered
+//                          slot + bank * bankSize. FNV-1a 32 over frame
+//                          height, frame count (big endian), and the raw
+//                          pattern bytes. 0 = unknown (empty slot).
 
 class OpenPixelPoiBLE : public BLEServerCallbacks, public BLECharacteristicCallbacks{
   
@@ -109,6 +126,37 @@ class OpenPixelPoiBLE : public BLEServerCallbacks, public BLECharacteristicCallb
 
     void bleSendFWVersion(){
       uint8_t response[] = {0xD0, 0x00, 0x06, CC_GET_FW_VERSION, 0x02, 0xD1};
+      writeToPixelPoi(response);
+    }
+
+    void bleSendState(){
+      const uint8_t hashCount = PATTERN_BANK_COUNT * PATTERN_BANK_SIZE;
+      const uint16_t length = 17 + hashCount * 4; // Framing (5) + fixed payload (12) + hashes
+      uint8_t response[length];
+      int i = 0;
+      response[i++] = 0xD0;
+      response[i++] = length >> 8;
+      response[i++] = length & 0xFF;
+      response[i++] = CC_GET_STATE;
+      response[i++] = config.displayState;
+      response[i++] = config.patternBank;
+      response[i++] = config.patternSlot;
+      response[i++] = config.ledBrightness;
+      response[i++] = config.animationSpeed >> 8;
+      response[i++] = config.animationSpeed & 0xFF;
+      response[i++] = config.patternShuffleDuration;
+      response[i++] = config.sequencerLength / 7;
+      response[i++] = (config.sequencerStep >> 8) & 0xFF;
+      response[i++] = config.sequencerStep & 0xFF;
+      response[i++] = PATTERN_BANK_COUNT;
+      response[i++] = PATTERN_BANK_SIZE;
+      for (uint8_t p = 0; p < hashCount; p++){
+        response[i++] = config.patternHashes[p] >> 24;
+        response[i++] = (config.patternHashes[p] >> 16) & 0xFF;
+        response[i++] = (config.patternHashes[p] >> 8) & 0xFF;
+        response[i++] = config.patternHashes[p] & 0xFF;
+      }
+      response[i++] = 0xD1;
       writeToPixelPoi(response);
     }
     
@@ -224,6 +272,8 @@ class OpenPixelPoiBLE : public BLEServerCallbacks, public BLECharacteristicCallb
             bleSendSuccess();
           }else if(requestCode == CC_GET_FW_VERSION){
             bleSendFWVersion();
+          }else if(requestCode == CC_GET_STATE){
+            bleSendState();
           }else if(requestCode == CC_SET_HARDWARE_VERSION){
             config.setHardwareVersion(bleStatus[2]);
             bleSendSuccess();

--- a/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_ble.cpp
+++ b/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_ble.cpp
@@ -1,5 +1,5 @@
 // Some things need to be included here, seems files are loaded alphabetically
-#include <arduino.h>
+#include <Arduino.h>
 #include <Update.h>
 #include "config.h"
 #include "open_pixel_poi_config.cpp"

--- a/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_config.cpp
+++ b/Firmware/open_pixel_poi_firmware_platformio/src/open_pixel_poi_config.cpp
@@ -64,10 +64,12 @@ class OpenPixelPoiConfig {
     uint8_t patternBank;
     uint8_t patternShuffleDuration;
     // Pattern
-    uint8_t frameHeight; 
+    uint8_t frameHeight;
     uint16_t frameCount;
     uint8_t *pattern = (uint8_t *) malloc(PATTERN_PIXEL_LIMIT * 3 * sizeof(uint8_t));
     uint32_t patternLength;
+    // FNV-1a hash per stored pattern (0 = unknown), indexed slot + bank * PATTERN_BANK_SIZE
+    uint32_t patternHashes[PATTERN_BANK_COUNT * PATTERN_BANK_SIZE];
     // Sequencer
     uint8_t *sequencer = (uint8_t *) malloc(1785*sizeof(uint8_t)); // 255 Instruction max (7 bits per instruction)
     uint16_t sequencerLength;
@@ -217,13 +219,92 @@ class OpenPixelPoiConfig {
         debugf("− failed to open file for writing\n");
       }else{
         debugf(" - opened file for writing: %d\n");
-        
+
         int written = file.write(pattern, patternLength);
         file.close();
         debugf(" - this much written: %d\n", written);
       }
-      
+
+      uint32_t hash = patternHashSeed();
+      hash = patternHashStep(hash, this->frameHeight);
+      hash = patternHashStep(hash, this->frameCount >> 8);
+      hash = patternHashStep(hash, this->frameCount & 0xFF);
+      for (uint32_t i=0; i<this->patternLength; i++) {
+        hash = patternHashStep(hash, this->pattern[i]);
+      }
+      setPatternHash(this->patternSlot + (this->patternBank * PATTERN_BANK_SIZE), hash);
+
       this->configLastUpdated = millis();
+    }
+
+    // FNV-1a 32 bit over frame height, frame count (big endian), and the raw
+    // pattern bytes. The app computes the same hash over its stored patterns
+    // to figure out which of them live in which slot on the poi.
+    static uint32_t patternHashSeed() {
+      return 2166136261u;
+    }
+
+    static uint32_t patternHashStep(uint32_t hash, uint8_t value) {
+      return (hash ^ value) * 16777619u;
+    }
+
+    void setPatternHash(uint8_t patternIndex, uint32_t hash) {
+      debugf("Save Pattern Hash %d = %08X\n", patternIndex, hash);
+      this->patternHashes[patternIndex] = hash;
+      String key = "p";
+      key += patternIndex;
+      key += "Hash";
+      preferences.putUInt(key.c_str(), hash);
+    }
+
+    // Hash a pattern already on flash, for patterns saved before hashes existed.
+    uint32_t computeStoredPatternHash(uint8_t patternIndex) {
+      File file = LittleFS.open(String("/pattern") + patternIndex + ".oppp");
+      if(!file || file.isDirectory()){
+        return 0;
+      }
+      String heightKey = "p";
+      heightKey += patternIndex;
+      heightKey += "Height";
+      String countKey = "p";
+      countKey += patternIndex;
+      countKey += "FCount";
+      uint8_t height = preferences.getChar(heightKey.c_str(), 5);
+      uint16_t count = preferences.getUShort(countKey.c_str(), 5);
+      uint32_t hash = patternHashSeed();
+      hash = patternHashStep(hash, height);
+      hash = patternHashStep(hash, count >> 8);
+      hash = patternHashStep(hash, count & 0xFF);
+      uint8_t buffer[256];
+      while(file.available() > 0){
+        int bytesRead = file.read(buffer, sizeof(buffer));
+        if(bytesRead <= 0){
+          break;
+        }
+        for(int i=0; i<bytesRead; i++){
+          hash = patternHashStep(hash, buffer[i]);
+        }
+      }
+      file.close();
+      return hash;
+    }
+
+    void loadPatternHashes() {
+      for (uint8_t i=0; i<PATTERN_BANK_COUNT * PATTERN_BANK_SIZE; i++){
+        String key = "p";
+        key += i;
+        key += "Hash";
+        if(preferences.isKey(key.c_str())){
+          this->patternHashes[i] = preferences.getUInt(key.c_str(), 0);
+        }else{
+          // One time backfill for patterns saved before hashes existed
+          this->patternHashes[i] = computeStoredPatternHash(i);
+          if(this->patternHashes[i] != 0){
+            preferences.putUInt(key.c_str(), this->patternHashes[i]);
+          }
+        }
+        debugf("- pattern hash %d = %08X\n", i, this->patternHashes[i]);
+      }
     }
 
     void fillDefaultPattern(){
@@ -372,6 +453,7 @@ class OpenPixelPoiConfig {
 
       startLoadingPattern();
       loadSequencer();
+      loadPatternHashes();
 
       debugf("- pattern\n");
       for (int i = 0; i < this->frameHeight * this->frameCount; i+=3 ) {


### PR DESCRIPTION
Adds a way for the app to ask the poi what is currently running and which patterns are stored, as a first step toward showing live state in the app. Draft because it compiles (PlatformIO, espressif32 6.4.0) but has not been flashed to hardware yet.

## Changes
- New `CC_GET_STATE` command (code 21) returning display state, active bank/slot, brightness, speed, shuffle duration, sequencer position, bank dimensions, and one 32 bit hash per stored pattern slot (payload documented in `open_pixel_poi_ble.cpp`)
- Pattern hashes are FNV-1a 32 over frame height, frame count, and the raw pattern bytes, computed on every `savePattern()` and persisted in Preferences (`pNHash`), so the app can compute the same hash over its own patterns and match slots
- One time backfill at boot hashes patterns saved by older firmware straight from LittleFS; empty slots report 0 (unknown)
- Fix `#include <arduino.h>` casing so the firmware builds on case sensitive filesystems (Linux)

## Testing
- Compiles clean with `pio run` (Flash 69.2%, RAM 11.5%, unchanged fixed RAM cost is 60 bytes for the hash table)
- Needs on-hardware verification: send `D0 15 D1`, expect a 77 byte response; save a pattern and confirm its hash changes; reboot once to confirm the backfill populates hashes for old patterns